### PR TITLE
Add Inline Variable support for APIs

### DIFF
--- a/modules/oauth-bff-rest/src/main/java/com/liferay/oauthbff/controller/OAuthProxyController.java
+++ b/modules/oauth-bff-rest/src/main/java/com/liferay/oauthbff/controller/OAuthProxyController.java
@@ -13,6 +13,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.io.InputStream;
+import java.util.Objects;
+import java.util.regex.Pattern;
 
 @Component(
         immediate = true,
@@ -125,7 +127,7 @@ public class OAuthProxyController {
         try {
             OAuthClient client = oAuthClientResolver.resolve(alias);
 
-            if (!isPathAllowed(client, proxyPath)) {
+            if (!_isPathAllowed(client, proxyPath)) {
                 _log.warn("Blocked proxy request to disallowed path: " + proxyPath);
                 return Response.status(Response.Status.FORBIDDEN)
                         .entity("{\"error\": \"Access to this endpoint is not allowed.\"}")
@@ -154,12 +156,79 @@ public class OAuthProxyController {
         }
     }
 
-    private boolean isPathAllowed(OAuthClient client, String proxyPath) {
-        String normalizedPath = proxyPath.startsWith("/") ? proxyPath : "/" + proxyPath;
+    private String[] _getSanitizedSegments(String path) {
+        String sanitizedPath = path;
 
-        return client.getAllowedEndpoints().stream()
-                .map(endpoint -> endpoint.startsWith("/") ? endpoint : "/" + endpoint)
-                .anyMatch(allowed -> normalizedPath.equals(allowed) || normalizedPath.startsWith(allowed + "/"));
+        if (sanitizedPath.startsWith("/")) {
+            sanitizedPath = sanitizedPath.substring(1);
+        }
+
+        if (sanitizedPath.endsWith("/")) {
+            sanitizedPath = sanitizedPath.substring(
+                0, sanitizedPath.length() - 1);
+        }
+
+        if (sanitizedPath.isEmpty()) {
+            return new String[0];
+        }
+
+        return sanitizedPath.split("/");
+    }
+
+    private boolean _isPathAllowed(OAuthClient client, String proxyPath) {
+        String normalizedPath =
+            proxyPath.startsWith("/") ? proxyPath : "/" + proxyPath;
+
+        return client.getAllowedEndpoints(
+        ).stream(
+        ).map(
+                endpoint -> endpoint.startsWith("/") ? endpoint : "/" + endpoint
+        ).anyMatch(
+            allowedEndpoint -> {
+                if (_inlineVariablePattern.matcher(
+                    allowedEndpoint
+                ).find()) {
+
+                    return _pathsMatch(allowedEndpoint, normalizedPath);
+                }
+
+                if (normalizedPath.equals(allowedEndpoint) ||
+                        normalizedPath.startsWith(allowedEndpoint + "/")) {
+
+                    return true;
+                }
+
+                return false;
+            }
+        );
+    }
+
+    private boolean _pathsMatch(String pattern, String path) {
+        String[] patternSegments = _getSanitizedSegments(pattern);
+        String[] pathSegments = _getSanitizedSegments(path);
+
+        if (patternSegments.length != pathSegments.length) {
+            return false;
+        }
+
+        for (int i = 0; i < patternSegments.length; i++) {
+            String patternSegment = patternSegments[i];
+            String pathSegment = pathSegments[i];
+
+            if (_inlineVariablePattern.matcher(
+                    patternSegment
+            ).matches()) {
+
+                if (pathSegment.isEmpty()) {
+                    return false;
+                }
+            }
+            else if (!Objects.equals(patternSegment, pathSegment)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private String getQueryString(UriInfo uriInfo) {
@@ -172,4 +241,8 @@ public class OAuthProxyController {
 
         return queryString;
     }
+
+    private static final Pattern _inlineVariablePattern = Pattern.compile(
+        "\\{[^/]+}");
+
 }


### PR DESCRIPTION
This PR provides inline variable support for the module by using a `Pattern` object and comparing it to the URLs for `allowedEndpoints` field.
1. Grab requested endpoint and allowedEndpoints
2. For each allowed endpoint, validate if it contains a variable (identified with curly braces within the request url, i.e. `{myVariable}`)
3. Validate that the requested endpoint has a) a value here and b) matches the pattern of the allowed endpoint