### PR TITLE
validate uri request format

### DIFF
--- a/modules/oauth-bff-rest/src/main/java/com/liferay/oauthbff/service/impl/ProxyServiceImpl.java
+++ b/modules/oauth-bff-rest/src/main/java/com/liferay/oauthbff/service/impl/ProxyServiceImpl.java
@@ -76,7 +76,21 @@ public class ProxyServiceImpl implements ProxyService {
     }
 
     private URI buildUri(String baseUrl, String path, String query) {
-        return URI.create(baseUrl + (path.startsWith("/") ? path : "/" + path) + (query == null || query.isBlank() ? "" : "?" + query));
+        String sanitizedBaseUrl = baseUrl;
+
+        while (sanitizedBaseUrl.endsWith("/")) {
+            sanitizedBaseUrl = sanitizedBaseUrl.substring(0, sanitizedBaseUrl.length() - 1);
+        }
+
+        StringBuilder uriString = new StringBuilder(sanitizedBaseUrl);
+
+        uriString.append((path.startsWith("/")) ? path : "/" + path);
+
+        if ((query != null) && !query.isBlank()) {
+            uriString.append("?").append(query);
+        }
+
+        return URI.create(uriString.toString());
     }
 
     private String resolveAuthHeader(OAuthClient client, TokenRequestContext context) {


### PR DESCRIPTION
A bug occurs where an extra forward slash exists between the baseURL and the path if the baseURL ends with a forward slash in the Object field (i.e. `my-baseurl.com//my-path`). This sanitizes the request url to ensure only 1 forward slash exists 